### PR TITLE
Quiet un/install functions

### DIFF
--- a/WaykNow/Public/WaykNowDen.ps1
+++ b/WaykNow/Public/WaykNowDen.ps1
@@ -36,7 +36,7 @@ function Get-WaykNowDen(
     $WaykNowObject.DenID = $denJson.denId
     $WaykNowObject.DenUrl = $settingJson.DenUrl
 
-    # TODO Remove this one when the Den Url will be alwways set in the settings file .cfg
+    # TODO Remove this one when the Den Url will be always set in the settings file .cfg
     if(!($WaykNowObject.DenUrl)){
         $WaykNowObject.DenUrl = "https://den.wayk.net"
     }


### PR DESCRIPTION
Add the -Quiet switch to un/install functions

On Windows, this sets the `/quiet` switch (for completely silent un/installs) in the args to msiexec.

If we don't specify -Quiet, the `/passive` switch is used: only a progress bar is shown.

The flags for msiexec are detailed here: https://www.advancedinstaller.com/user-guide/msiexec.html